### PR TITLE
fix: hdfs name err in e2e and chart dep version err in chart test

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -117,7 +117,7 @@ jobs:
 
           # Install dependencies
           for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep kubedoop/$dep
+            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep kubedoop/$dep --version ${{ env.VERSION }}
           done
 
           # Install hbase-operator chart

--- a/test/e2e/kerberos/hdfs-assert.yaml
+++ b/test/e2e/kerberos/hdfs-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: krb5-hdfs-default-journalnode
+  name: krb5-hdfs-journalnode-default
 status:
   availableReplicas: 1
   replicas: 1
@@ -21,7 +21,7 @@ status:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: krb5-hdfs-default-namenode
+  name: krb5-hdfs-namenode-default
 status:
   availableReplicas: 2
   replicas: 2
@@ -29,7 +29,7 @@ status:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: krb5-hdfs-default-datanode
+  name: krb5-hdfs-datanode-default
 status:
   availableReplicas: 1
   replicas: 1

--- a/test/e2e/setup/hdfs-assert.yaml
+++ b/test/e2e/setup/hdfs-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: hdfs-default-journalnode
+  name: hdfs-journalnode-default
 status:
   availableReplicas: 1
   replicas: 1
@@ -21,7 +21,7 @@ status:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: hdfs-default-namenode
+  name: hdfs-namenode-default
 status:
   availableReplicas: 2
   replicas: 2
@@ -29,7 +29,7 @@ status:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: hdfs-default-datanode
+  name: hdfs-datanode-default
 status:
   availableReplicas: 1
   replicas: 1


### PR DESCRIPTION
## Summary by Sourcery

Fix HDFS StatefulSet naming in end-to-end test assertions and ensure chart-lint-test installs dependencies with the correct version

Bug Fixes:
- Correct HDFS StatefulSet resource names in e2e and setup test YAMLs to use the '<component>-default' format

CI:
- Include --version flag when installing Helm dependencies in the chart-lint-test workflow